### PR TITLE
fix some bugs, add toroidal padding for non-equivariant models

### DIFF
--- a/scripts/cfd_2d.py
+++ b/scripts/cfd_2d.py
@@ -65,10 +65,7 @@ def get_data(
         pressure = (pressure - jnp.mean(pressure[: (n_train + n_val)])) / jnp.std(
             pressure[: (n_train + n_val)]
         )
-        # TODO: this is not equivariant :/
-        velocity = velocity / jnp.std(
-            velocity[: (n_train + n_val)]
-        )  # this one I am not so sure about
+        velocity = velocity / jnp.std(jnp.linalg.norm(velocity[: n_train + n_val], axis=-1))
 
     # (batch,2,timesteps,spatial)
     density_pressure = jnp.concatenate([density[:, None], pressure[:, None]], axis=1)
@@ -472,6 +469,7 @@ train_kwargs = {
     "is_wandb": args.wandb,
 }
 
+padding_mode = "CIRCULAR" if data[0].is_torus == (True,) * D else "ZEROS"
 key, *subkeys = random.split(key, num=13)
 model_list = [
     (
@@ -485,6 +483,7 @@ model_list = [
                 depth=64,
                 equivariant=False,
                 kernel_size=3,
+                padding_mode=padding_mode,
                 key=subkeys[0],
             ),
             "lr": 2e-3,
@@ -534,6 +533,7 @@ model_list = [
                 depth=128,
                 equivariant=False,
                 kernel_size=3,
+                padding_mode=padding_mode,
                 key=subkeys[3],
             ),
             "lr": 1e-3,
@@ -586,6 +586,7 @@ model_list = [
                 equivariant=False,
                 kernel_size=3,
                 use_group_norm=True,
+                padding_mode=padding_mode,
                 key=subkeys[6],
             ),
             "lr": 8e-4,
@@ -640,6 +641,7 @@ model_list = [
                 equivariant=False,
                 kernel_size=3,
                 use_batch_norm=True,
+                padding_mode=padding_mode,
                 key=subkeys[9],
             ),
             "lr": 8e-4,

--- a/scripts/exploratory/gradient_sphere.py
+++ b/scripts/exploratory/gradient_sphere.py
@@ -2,7 +2,7 @@ import time
 import argparse
 import functools
 import numpy as np
-from typing_extensions import Any, Callable, Optional, Union
+from typing_extensions import Callable, Optional
 
 import jax.numpy as jnp
 import jax
@@ -17,72 +17,106 @@ import ginjax.models as models
 import ginjax.utils as utils
 
 
-def f(coord: jax.Array, coeffs: jax.Array) -> jax.Array:
-    x, y = coord
-    # third_degree_poly = jnp.array([1, x, y, x**2, x * y, y**2, x**3, x**2 * y, x * y**2, y**3])
-    trig = jnp.array([jnp.sin(x), jnp.sin(y), jnp.cos(x), jnp.cos(y)])
-    trig_squared = jnp.concatenate(
-        [
-            trig**2,
-            jnp.array(
-                [
-                    jnp.sin(x) * jnp.cos(x),
-                    jnp.sin(y) * jnp.cos(y),
-                    jnp.sin(x) * jnp.cos(y),
-                    jnp.sin(y) * jnp.cos(x),
-                ]
-            ),
-        ]
-    )
-    library = jnp.concatenate([trig, trig_squared])  # 12 total
-    # mixed = jnp.einsum("i,j->ij", third_degree_poly, jnp.concatenate([trig, trig_squared]))
-    # library = jnp.concatenate([third_degree_poly, mixed.reshape(-1)])
+def f(p: jax.Array, coeffs: jax.Array) -> jax.Array:
+    """
+    Scalar function on the 2d torus at point p
+
+    args:
+        p: 2d array of x,y coordinates
+        coeffs: 2*D + (2*D choose 2) (=14 for D=2) coefficients to construct our function with
+    """
+    trig = jnp.concatenate([jnp.sin(p), jnp.cos(p)])
+    trig_squared = jnp.einsum("i,j->ij", trig, trig)[jnp.triu_indices(len(trig))]
+    library = jnp.concatenate([trig, trig_squared])  # 14 total
 
     return jnp.einsum("i,i->", library, coeffs)
 
 
-def metric_f(coords: jax.Array) -> jax.Array:
-    x, y = coords
+def metric_f(p: jax.Array) -> jax.Array:
+    """
+    Metric tensor at point p of the typical round metric on a sphere.
+
+    args:
+        p: the point on the surface
+
+    returns:
+        2D metric tensor g_ij
+    """
+    x, _ = p
     return jnp.array([[1, 0], [0, jnp.sin(x) ** 2]])
 
 
-def metric_inv_f(coords: jax.Array) -> jax.Array:
-    x, y = coords
+def metric_inv_f(p: jax.Array) -> jax.Array:
+    """
+    Inverse metric tensor at point p of the typical round metric on a sphere.
+
+    args:
+        p: the point on the surface
+
+    returns:
+        2D inverse metric tensor g^ij
+    """
+    x, _ = p
     return jnp.array([[1, 0], [0, 1 / jnp.sin(x) ** 2]])
 
 
-def christoffel_f(coords: jax.Array) -> jax.Array:
-    # new dimension is added at the end
-    metric_partial = jax.jacfwd(metric_f)(coords)
+def christoffel_f(p: jax.Array) -> jax.Array:
+    """
+    Christoffel symbols at point p on a surface with a metric tensor given by metric_f
+
+    args:
+        p: the point on the surface
+
+    returns:
+        Christoffel symbol Lambda^k_ij
+    """
+    metric_partial = jax.jacfwd(metric_f)(p)
     assert isinstance(metric_partial, jax.Array)
     metric_sum = (
         metric_partial.transpose(1, 2, 0) + metric_partial.transpose(2, 0, 1) - metric_partial
     )
-    metric_inv = metric_inv_f(coords)
+    metric_inv = metric_inv_f(p)
     return 0.5 * jnp.einsum("kl,ijl->kij", metric_inv, metric_sum)
 
 
-def covariant_derivative(coords: jax.Array, f: Callable) -> jax.Array:
+def covariant_derivative(p: jax.Array, f: Callable) -> jax.Array:
+    """
+    Calculate the covariant derivative at point p of function f
+
+    args:
+        p: the point on the surface
+        f: the scalar function defined on the surface
+
+    returns:
+        the covariant derivative of the gradient, (delta_f)_c;a
+    """
     # covariant derivative of a covariant vector, grad
     grad_f = jax.grad(f)
     hessian_f = jax.jacfwd(grad_f)
 
-    grad = grad_f(coords)
-    hessian = hessian_f(coords)
-    christoffel = christoffel_f(coords)
+    grad = grad_f(p)
+    hessian = hessian_f(p)
+    christoffel = christoffel_f(p)
     return hessian - jnp.einsum("bca,b->ca", christoffel, grad)
 
 
 def get_dataset(D: int, n_images: int, key: jax.Array) -> tuple[geom.MultiImage, geom.MultiImage]:
+    """
+    Calculate a dataset of scalar function -> gradient of the scalar function
+
+    args:
+        D: the dimension of the space
+        n_images: the number of images to generate
+        key: random key
+
+    returns:
+        input scalar image and output gradient image
+    """
     N = 16
-    spatial_dims = (N, 2 * N)
-    # 96 values, excluding the singularities
-    # theta_range = jnp.linspace(0, jnp.pi, num=spatial_dims[0] + 2)[1:-1]
-    # # 192 values
-    # phi_range = jnp.linspace(0, 2 * jnp.pi, num=spatial_dims[1])
+    spatial_dims = (N, N)
 
     # skip 0 because 0 and 2pi are equal
-    theta_range = jnp.linspace(0, jnp.pi, num=spatial_dims[0] + 1)[1:]
+    theta_range = jnp.linspace(0, 2 * jnp.pi, num=spatial_dims[0] + 1)[1:]
     phi_range = jnp.linspace(0, 2 * jnp.pi, num=spatial_dims[1] + 1)[1:]
 
     # avoid singularities at theta=0,pi,2pi
@@ -99,7 +133,7 @@ def get_dataset(D: int, n_images: int, key: jax.Array) -> tuple[geom.MultiImage,
     for _ in range(n_images):
         key, subkey = random.split(key)
         # 130 for full library
-        coeffs = random.normal(subkey, shape=(12,))  # hardcoded library size
+        coeffs = random.normal(subkey, shape=(14,))  # hardcoded library size
         f_partial = functools.partial(f, coeffs=coeffs)
         # could maybe start from grad instead of scalar?
         scalar_image = jax.vmap(f_partial)(grid_flattened).reshape((1, 1) + spatial_dims)
@@ -138,25 +172,25 @@ def get_dataset(D: int, n_images: int, key: jax.Array) -> tuple[geom.MultiImage,
     X = geom.MultiImage(
         {((), 0): scalar_images},
         D,
-        (False, True),
-        metric_tensor,
-        metric_tensor_inv,
-    )
-    Y = geom.MultiImage(
-        {((True, True), 0): covariant_deriv_images},
-        D,
-        (False, True),
-        metric_tensor,
-        metric_tensor_inv,
+        (True, True),
+        # metric_tensor,
+        # metric_tensor_inv,
     )
     # Y = geom.MultiImage(
-    #     {((True,), 0): grad_images},
+    #     {((True, True), 0): covariant_deriv_images},
     #     D,
-    #     (False, True),
-    #     # (False, True),
-    #     # metric_tensor,
-    #     # metric_tensor_inv,
+    #     (True, True),
+    #     metric_tensor,
+    #     metric_tensor_inv,
     # )
+    Y = geom.MultiImage(
+        {((True,), 0): grad_images},
+        D,
+        (True, True),
+        # (False, True),
+        # metric_tensor,
+        # metric_tensor_inv,
+    )
 
     return X, Y
 
@@ -368,26 +402,6 @@ model_list = [
             **train_kwargs,
         },
     ),
-    # (
-    #     "resnet_group_average",
-    #     train_and_eval,
-    #     {
-    #         "model": models.GroupAverage(
-    #             models.ResNet(
-    #                 D,
-    #                 input_keys,
-    #                 output_keys,
-    #                 depth=128,
-    #                 equivariant=False,
-    #                 kernel_size=3,
-    #                 key=subkeys[1],
-    #             ),
-    #             group_actions,
-    #         ),
-    #         "lr": 1e-3,
-    #         **train_kwargs,
-    #     },
-    # ),
     (
         "resnet_equiv_42",
         train_and_eval,
@@ -399,7 +413,6 @@ model_list = [
                 depth=42,
                 conv_filters=conv_filters,
                 use_group_norm=False,
-                # mid_keys=
                 key=subkeys[1],
             ),
             "lr": 7e-4,

--- a/scripts/exploratory/gradient_sphere.py
+++ b/scripts/exploratory/gradient_sphere.py
@@ -1,0 +1,426 @@
+import time
+import argparse
+import functools
+import numpy as np
+from typing_extensions import Any, Callable, Optional, Union
+
+import jax.numpy as jnp
+import jax
+import jax.random as random
+from jaxtyping import ArrayLike
+import optax
+import equinox as eqx
+
+import ginjax.geometric as geom
+import ginjax.ml as ml
+import ginjax.models as models
+import ginjax.utils as utils
+
+
+def f(coord: jax.Array, coeffs: jax.Array) -> jax.Array:
+    x, y = coord
+    # third_degree_poly = jnp.array([1, x, y, x**2, x * y, y**2, x**3, x**2 * y, x * y**2, y**3])
+    trig = jnp.array([jnp.sin(x), jnp.sin(y), jnp.cos(x), jnp.cos(y)])
+    trig_squared = jnp.concatenate(
+        [
+            trig**2,
+            jnp.array(
+                [
+                    jnp.sin(x) * jnp.cos(x),
+                    jnp.sin(y) * jnp.cos(y),
+                    jnp.sin(x) * jnp.cos(y),
+                    jnp.sin(y) * jnp.cos(x),
+                ]
+            ),
+        ]
+    )
+    library = jnp.concatenate([trig, trig_squared])  # 12 total
+    # mixed = jnp.einsum("i,j->ij", third_degree_poly, jnp.concatenate([trig, trig_squared]))
+    # library = jnp.concatenate([third_degree_poly, mixed.reshape(-1)])
+
+    return jnp.einsum("i,i->", library, coeffs)
+
+
+def metric_f(coords: jax.Array) -> jax.Array:
+    x, y = coords
+    return jnp.array([[1, 0], [0, jnp.sin(x) ** 2]])
+
+
+def metric_inv_f(coords: jax.Array) -> jax.Array:
+    x, y = coords
+    return jnp.array([[1, 0], [0, 1 / jnp.sin(x) ** 2]])
+
+
+def christoffel_f(coords: jax.Array) -> jax.Array:
+    # new dimension is added at the end
+    metric_partial = jax.jacfwd(metric_f)(coords)
+    assert isinstance(metric_partial, jax.Array)
+    metric_sum = (
+        metric_partial.transpose(1, 2, 0) + metric_partial.transpose(2, 0, 1) - metric_partial
+    )
+    metric_inv = metric_inv_f(coords)
+    return 0.5 * jnp.einsum("kl,ijl->kij", metric_inv, metric_sum)
+
+
+def covariant_derivative(coords: jax.Array, f: Callable) -> jax.Array:
+    # covariant derivative of a covariant vector, grad
+    grad_f = jax.grad(f)
+    hessian_f = jax.jacfwd(grad_f)
+
+    grad = grad_f(coords)
+    hessian = hessian_f(coords)
+    christoffel = christoffel_f(coords)
+    return hessian - jnp.einsum("bca,b->ca", christoffel, grad)
+
+
+def get_dataset(D: int, n_images: int, key: jax.Array) -> tuple[geom.MultiImage, geom.MultiImage]:
+    N = 16
+    spatial_dims = (N, 2 * N)
+    # 96 values, excluding the singularities
+    # theta_range = jnp.linspace(0, jnp.pi, num=spatial_dims[0] + 2)[1:-1]
+    # # 192 values
+    # phi_range = jnp.linspace(0, 2 * jnp.pi, num=spatial_dims[1])
+
+    # skip 0 because 0 and 2pi are equal
+    theta_range = jnp.linspace(0, jnp.pi, num=spatial_dims[0] + 1)[1:]
+    phi_range = jnp.linspace(0, 2 * jnp.pi, num=spatial_dims[1] + 1)[1:]
+
+    # avoid singularities at theta=0,pi,2pi
+    theta_range += theta_range[0] / 2
+    phi_range += phi_range[0] / 2
+
+    grid = jnp.stack(jnp.meshgrid(theta_range, phi_range, indexing="ij"), axis=-1)
+    grid_flattened = grid.reshape((-1, D))
+
+    scalar_images = jnp.zeros((0, 1) + spatial_dims)
+    grad_images = jnp.zeros((0, 1) + spatial_dims + (D,))
+    covariant_deriv_images = jnp.zeros((0, 1) + spatial_dims + (D, D))
+
+    for _ in range(n_images):
+        key, subkey = random.split(key)
+        # 130 for full library
+        coeffs = random.normal(subkey, shape=(12,))  # hardcoded library size
+        f_partial = functools.partial(f, coeffs=coeffs)
+        # could maybe start from grad instead of scalar?
+        scalar_image = jax.vmap(f_partial)(grid_flattened).reshape((1, 1) + spatial_dims)
+        scalar_images = jnp.concatenate([scalar_images, scalar_image])
+
+        grad_image = jax.vmap(jax.grad(f_partial))(grid_flattened).reshape(
+            (1, 1) + spatial_dims + (D,)
+        )
+        grad_images = jnp.concatenate([grad_images, grad_image])
+
+        covariant_deriv_image = jax.vmap(covariant_derivative, in_axes=(0, None))(
+            grid_flattened, f_partial
+        ).reshape((1, 1) + spatial_dims + (D, D))
+        covariant_deriv_images = jnp.concatenate(
+            [
+                covariant_deriv_images,
+                covariant_deriv_image,
+            ]
+        )
+
+    metric_tensor = geom.GeometricImage(
+        jax.vmap(metric_f)(grid_flattened).reshape(spatial_dims + (D, D)),
+        0,
+        D,
+        (False, True),
+        (True, True),
+    )
+    metric_tensor_inv = geom.GeometricImage(
+        jax.vmap(metric_inv_f)(grid_flattened).reshape(spatial_dims + (D, D)),
+        0,
+        D,
+        (False, True),
+        (True, True),
+    )
+
+    X = geom.MultiImage(
+        {((), 0): scalar_images},
+        D,
+        (False, True),
+        metric_tensor,
+        metric_tensor_inv,
+    )
+    Y = geom.MultiImage(
+        {((True, True), 0): covariant_deriv_images},
+        D,
+        (False, True),
+        metric_tensor,
+        metric_tensor_inv,
+    )
+    # Y = geom.MultiImage(
+    #     {((True,), 0): grad_images},
+    #     D,
+    #     (False, True),
+    #     # (False, True),
+    #     # metric_tensor,
+    #     # metric_tensor_inv,
+    # )
+
+    return X, Y
+
+
+def get_data(
+    D: int, n_train: int, n_val: int, n_test: int, normalize: bool, key: jax.Array
+) -> tuple[
+    geom.MultiImage,
+    geom.MultiImage,
+    geom.MultiImage,
+    geom.MultiImage,
+    geom.MultiImage,
+    geom.MultiImage,
+]:
+    key, subkey1, subkey2, subkey3 = random.split(key, num=4)
+    train_X, train_Y = get_dataset(D, n_train, subkey1)
+    val_X, val_Y = get_dataset(D, n_val, subkey2)
+    test_X, test_Y = get_dataset(D, n_test, subkey3)
+
+    if normalize:
+
+        for (k, parity), train_block in train_X.items():
+            non_test_X = jnp.concatenate([train_block, val_X[(k, parity)]])
+
+            if k == ():
+                mean_X = jnp.mean(non_test_X, axis=(0,) + tuple(range(2, 2 + D)))
+                std_X = jnp.std(non_test_X, axis=(0,) + tuple(range(2, 2 + D)))
+            else:
+                mean_X = jnp.zeros((1, non_test_X.shape[1]) + (1,) * D)
+                norm = jnp.linalg.norm(
+                    non_test_X, axis=tuple(range(non_test_X.ndim - len(k), non_test_X.ndim))
+                )
+                assert norm.shape == non_test_X.shape[: non_test_X.ndim - len(k)]
+                std_X = jnp.std(norm, axis=(0,) + tuple(range(2, 2 + D)))
+
+            train_X[((), 0)] = (train_X[((), 0)] - mean_X) / std_X
+            val_X[((), 0)] = (val_X[((), 0)] - mean_X) / std_X
+            test_X[((), 0)] = (test_X[((), 0)] - mean_X) / std_X
+
+    return train_X, train_Y, val_X, val_Y, test_X, test_Y
+
+
+@eqx.filter_jit
+def map_and_loss(
+    model: models.MultiImageModule,
+    multi_image_x: geom.MultiImage,
+    multi_image_y: geom.MultiImage,
+    aux_data: Optional[eqx.nn.State] = None,
+) -> tuple[jax.Array, Optional[eqx.nn.State]]:
+    vmap_model = jax.vmap(model, in_axes=(0, None), out_axes=(0, None))
+    pred_y, aux_data = vmap_model(multi_image_x, aux_data)
+    loss = ml.smse_loss(pred_y, multi_image_y)
+
+    return loss, aux_data
+
+
+def train_and_eval(
+    data: tuple[geom.MultiImage, ...],
+    key: jax.Array,
+    model_name: str,
+    model: models.MultiImageModule,
+    lr: float,
+    batch_size: int,
+    epochs: int,
+    save_model: Optional[str],
+    load_model: Optional[str],
+    has_aux: bool = False,
+    verbose: int = 1,
+    is_wandb: bool = False,
+) -> tuple[Optional[ArrayLike], Optional[ArrayLike], jax.Array]:
+    (
+        train_X,
+        train_Y,
+        val_X,
+        val_Y,
+        test_X,
+        test_Y,
+    ) = data
+    batch_stats = eqx.nn.State(model) if has_aux else None
+
+    print(f"Model params: {models.count_params(model):,}")
+
+    if load_model is None:
+        steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
+        key, subkey = random.split(key)
+        model, batch_stats, train_loss, val_loss = ml.train(
+            train_X,
+            train_Y,
+            map_and_loss,
+            model,
+            subkey,
+            stop_condition=ml.EpochStop(epochs, verbose=verbose),
+            batch_size=batch_size,
+            optimizer=optax.adamw(
+                optax.warmup_cosine_decay_schedule(
+                    1e-8, lr, 5 * steps_per_epoch, epochs * steps_per_epoch, 1e-7
+                ),
+                weight_decay=1e-5,
+            ),
+            validation_X=val_X,
+            validation_Y=val_Y,
+            aux_data=batch_stats,
+            is_wandb=is_wandb,
+        )
+
+        if save_model is not None:
+            # TODO: need to save batch_stats as well
+            ml.save(f"{save_model}{model_name}_L{train_X.get_L()}_e{epochs}_model.eqx", model)
+    else:
+        model = ml.load(f"{load_model}{model_name}_L{train_X.get_L()}_e{epochs}_model.eqx", model)
+
+        key, subkey1, subkey2 = random.split(key, num=3)
+        train_loss = ml.map_loss_in_batches(
+            map_and_loss,
+            model,
+            train_X,
+            train_Y,
+            batch_size,
+            subkey1,
+            aux_data=batch_stats,
+        )
+        val_loss = ml.map_loss_in_batches(
+            map_and_loss,
+            model,
+            val_X,
+            val_Y,
+            batch_size,
+            subkey2,
+            aux_data=batch_stats,
+        )
+
+    key, subkey = random.split(key)
+    test_loss = ml.map_loss_in_batches(
+        map_and_loss,
+        model,
+        test_X,
+        test_Y,
+        batch_size,
+        subkey,
+        aux_data=batch_stats,
+    )
+    print(f"Test Loss: {test_loss}")
+
+    vmap_model = jax.vmap(model, in_axes=(0, None), out_axes=(0, None))
+    out = None
+    for gg in geom.make_all_operators(D):
+        gg_out = vmap_model(test_X.times_gg_precise(gg), None)[0].times_gg_precise(gg.T)
+        out = gg_out if out is None else out + gg_out
+
+    assert out is not None
+    out = out / len(geom.make_all_operators(D))
+    test_loss1 = ml.smse_loss(out, test_Y)
+    print(f"Group Average Test Loss Manual: {test_loss1}")
+
+    return train_loss, val_loss, test_loss
+
+
+def handleArgs() -> argparse.Namespace:
+    parser = utils.get_common_parser()
+    parser.add_argument(
+        "--wandb-project", help="the wandb project", type=str, default="gradient-sphere"
+    )
+    return parser.parse_args()
+
+
+# Main
+args = handleArgs()
+D = 2
+
+key = random.PRNGKey(time.time_ns()) if (args.seed is None) else random.PRNGKey(args.seed)
+
+key, subkey = random.split(key)
+data = get_data(D, args.n_train, args.n_val, args.n_test, args.normalize, subkey)
+
+input_keys = data[0].get_signature()
+output_keys = data[1].get_signature()
+
+group_actions = geom.make_all_operators(D)
+conv_filters = geom.get_invariant_filters(
+    Ms=[3], ks=[0, 1, 2], parities=[0, 1], D=D, operators=group_actions
+)
+assert conv_filters is not None
+
+train_kwargs = {
+    "batch_size": args.batch,
+    "epochs": args.epochs,
+    "save_model": args.save_model,
+    "load_model": args.load_model,
+    "verbose": args.verbose,
+    "is_wandb": args.wandb,
+}
+
+key, *subkeys = random.split(key, num=12)
+model_list = [
+    (
+        "resnet",
+        train_and_eval,
+        {
+            "model": models.ResNet(
+                D,
+                input_keys,
+                output_keys,
+                depth=128,
+                equivariant=False,
+                kernel_size=3,
+                key=subkeys[0],
+            ),
+            "lr": 1e-3,
+            **train_kwargs,
+        },
+    ),
+    # (
+    #     "resnet_group_average",
+    #     train_and_eval,
+    #     {
+    #         "model": models.GroupAverage(
+    #             models.ResNet(
+    #                 D,
+    #                 input_keys,
+    #                 output_keys,
+    #                 depth=128,
+    #                 equivariant=False,
+    #                 kernel_size=3,
+    #                 key=subkeys[1],
+    #             ),
+    #             group_actions,
+    #         ),
+    #         "lr": 1e-3,
+    #         **train_kwargs,
+    #     },
+    # ),
+    (
+        "resnet_equiv_42",
+        train_and_eval,
+        {
+            "model": models.ResNet(
+                D,
+                input_keys,
+                output_keys,
+                depth=42,
+                conv_filters=conv_filters,
+                use_group_norm=False,
+                # mid_keys=
+                key=subkeys[1],
+            ),
+            "lr": 7e-4,
+            **train_kwargs,
+        },
+    ),
+]
+
+key, subkey = random.split(key)
+
+# Use this for benchmarking the models with known learning rates.
+results = ml.benchmark(
+    lambda _: data,
+    model_list,
+    subkey,
+    "",
+    [0],
+    benchmark_type=ml.BENCHMARK_NONE,
+    num_trials=args.n_trials,
+    num_results=3,
+    is_wandb=args.wandb,
+    wandb_project=args.wandb_project,
+    wandb_entity=args.wandb_entity,
+)

--- a/scripts/shallow_water.py
+++ b/scripts/shallow_water.py
@@ -431,7 +431,7 @@ def get_data(
         # val_div = (val_div - div_mean) / div_std
         # test_div = (test_div - div_mean) / div_std
 
-        uv_std = jnp.std(jnp.concatenate([train_uv, val_uv]))
+        uv_std = jnp.std(jnp.linalg.norm(jnp.concatenate([train_uv, val_uv]), axis=-1))
         train_uv = train_uv / uv_std
         val_uv = val_uv / uv_std
         test_uv = test_uv / uv_std

--- a/src/ginjax/geometric/__init__.py
+++ b/src/ginjax/geometric/__init__.py
@@ -11,6 +11,7 @@ from .functional_geometric_image import (
     norm as norm,
     parse_shape as parse_shape,
     raise_lower as raise_lower,
+    rotate_is_torus as rotate_is_torus,
     times_group_element as times_group_element,
     tensor_times_gg as tensor_times_gg,
 )

--- a/src/ginjax/geometric/functional_geometric_image.py
+++ b/src/ginjax/geometric/functional_geometric_image.py
@@ -647,7 +647,7 @@ def times_group_element(
     sign, _ = jnp.linalg.slogdet(gg)
     parity_flip = sign**parity  # if parity=1, the flip operators don't flip the tensors
 
-    rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))  # inverse gg?
+    rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))
     rotated_keys = get_rotated_keys(D, spatial_dims, gg)
 
     # hash, then reshape keys

--- a/src/ginjax/geometric/functional_geometric_image.py
+++ b/src/ginjax/geometric/functional_geometric_image.py
@@ -33,21 +33,21 @@ def parse_shape(shape: tuple[int, ...], D: int) -> tuple[tuple[int, ...], int]:
     return shape[:D], len(shape) - D
 
 
-def hash(D: int, image: jax.Array, indices: ArrayLike) -> tuple[jax.Array, ...]:
+def hash(D: int, spatial_dims: tuple[int, ...], indices: ArrayLike) -> tuple[jax.Array, ...]:
     """
     Converts an array of indices to their pixels on the torus by modding the indices with the
     spatial dimensions.
 
     args:
         D: dimension of the image
-        image: image data
+        spatial_dims: the spatial dimensions of the data
         indices: array of indices, shape (num_idx, D) to apply the remainder to
 
     returns:
         the pixel indices as a d-tuple of jax arrays
     """
-    spatial_dims = jnp.array(parse_shape(image.shape, D)[0]).reshape((1, D))
-    return tuple(jnp.remainder(indices, spatial_dims).transpose().astype(int))
+    spatial_dims_array = jnp.array(spatial_dims).reshape((1, D))
+    return tuple(jnp.remainder(indices, spatial_dims_array).transpose().astype(int))
 
 
 def get_torus_expanded(
@@ -589,7 +589,7 @@ def raise_lower(
     return jnp.einsum(einstr, *tensor_inputs, precision=precision)
 
 
-def get_rotated_keys(D: int, data: jax.Array, gg: np.ndarray) -> np.ndarray:
+def get_rotated_keys(D: int, spatial_dims: tuple[int, ...], gg: np.ndarray) -> np.ndarray:
     """
     Get the rotated keys of data when it will be rotated by gg. Note that we rotate the key vector indices
     by the inverse of gg per the definition (this is done by key_array @ gg, rather than gg @ key_array).
@@ -598,22 +598,22 @@ def get_rotated_keys(D: int, data: jax.Array, gg: np.ndarray) -> np.ndarray:
 
     args:
         D: dimension of image
-        data: data array to be rotated
+        spatial_dims: the spatial dimensions of the data to be rotated
         gg: group operation
 
     returns:
         the rotated keys
     """
-    spatial_dims, _ = parse_shape(data.shape, D)
     rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))
 
     # When spatial_dims is nonsquare, we have to subtract one version, then add the rotated version.
-    centering_coords = (np.array(rotated_spatial_dims).reshape((1, D)) - 1) / 2
-    rotated_centering_coords = np.abs(gg @ centering_coords.reshape((D, 1))).reshape((1, D))
+    centering_coords = (np.array(spatial_dims).reshape((1, D)) - 1) / 2
+    rot_centering_coords = (np.array(rotated_spatial_dims).reshape((1, D)) - 1) / 2
+
     # rotated keys will need to have the rotated_spatial_dims numbers
     key_array = np.array([key for key in it.product(*list(range(N) for N in rotated_spatial_dims))])
-    shifted_key_array = key_array - centering_coords
-    return np.rint((shifted_key_array @ gg) + rotated_centering_coords).astype(int)
+    shifted_key_array = key_array - rot_centering_coords
+    return np.rint((shifted_key_array @ gg) + centering_coords).astype(int)
 
 
 def times_group_element(
@@ -630,25 +630,31 @@ def times_group_element(
 
     args:
         D: dimension of the data
-        data: data block of image data to rotate, shape (spatial,tensor)
+        data: data block of image data to rotate, shape (batch,spatial,tensor)
         parity: parity of the data, 0 for even parity, 1 for odd parity
         gg: a DxD matrix that rotates the tensor. Note that you cannot vmap by this argument
             because it needs to deal with concrete values
-        covariant_axes: which axes of the tensor are covariant (True) or contravariant (False)
+        covariant_axes: which axes of the tensor are covariant (True) or contravariant (False).
+            Also specifies the number of tensor axes.
         precision: einsum precision, normally uses lower precision, use jax.lax.Precision.HIGHEST
             for testing equality in unit tests
 
     returns:
         the rotated image data
     """
-    spatial_dims, k = parse_shape(data.shape, D)
-    assert len(covariant_axes) == k, f"times_group_element: Must be {k} axes, got {covariant_axes}"
+    n_lead = data.ndim - D - len(covariant_axes)
+    spatial_dims, k = parse_shape(data.shape[n_lead:], D)
     sign, _ = jnp.linalg.slogdet(gg)
     parity_flip = sign**parity  # if parity=1, the flip operators don't flip the tensors
 
-    rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))
-    rotated_keys = get_rotated_keys(D, data, gg)
-    rotated_pixels = data[hash(D, data, rotated_keys)].reshape(rotated_spatial_dims + (D,) * k)
+    rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))  # inverse gg?
+    rotated_keys = get_rotated_keys(D, spatial_dims, gg)
+
+    # hash, then reshape keys
+    vmap_hash = jax.vmap(lambda x: x[hash(D, spatial_dims, rotated_keys)])
+    rotated_pixels = vmap_hash(data.reshape((-1,) + spatial_dims + (D,) * k)).reshape(
+        (data.shape[:n_lead] + rotated_spatial_dims + (D,) * k)
+    )
 
     if k == 0:
         newdata = 1.0 * rotated_pixels * parity_flip
@@ -667,6 +673,10 @@ def times_group_element(
         newdata = jnp.einsum(einstr, *tensor_inputs, precision=precision) * (parity_flip)
 
     return newdata
+
+
+def rotate_is_torus(is_torus: tuple[bool, ...], gg: np.ndarray) -> tuple[bool, ...]:
+    return tuple(is_torus[idx] for idx in np.abs(gg @ np.arange(len(is_torus))))
 
 
 def tensor_times_gg(

--- a/src/ginjax/geometric/geometric_image.py
+++ b/src/ginjax/geometric/geometric_image.py
@@ -13,7 +13,6 @@ from ginjax.geometric.constants import LeviCivitaSymbol, KroneckerDeltaSymbol, T
 from ginjax.geometric.functional_geometric_image import (
     average_pool,
     convolve,
-    get_rotated_keys,
     hash,
     max_pool,
     mul,
@@ -21,6 +20,7 @@ from ginjax.geometric.functional_geometric_image import (
     norm,
     parse_shape,
     raise_lower,
+    rotate_is_torus,
     times_group_element,
 )
 import ginjax.utils as utils
@@ -181,7 +181,7 @@ class GeometricImage:
         returns:
             the pixel indices as a d-tuple of jax arrays
         """
-        return hash(self.D, self.data, indices)
+        return hash(self.D, self.spatial_dims, indices)
 
     def __getitem__(self: Self, key: Any) -> jax.Array:
         """
@@ -725,19 +725,6 @@ class GeometricImage:
         """
         return self.raise_lower(metric_tensor, metric_tensor_inv, axes, jax.lax.Precision.HIGHEST)
 
-    def get_rotated_keys(self: Self, gg: np.ndarray) -> np.ndarray:
-        """
-        Get the rotated keys of this GeometricImage by the rotation gg.
-        Slightly messier than with GeometricFilter because self.N-1 / 2 might not be an integer, but should work
-
-        args:
-            gg: a DxD matrix that rotates the tensor
-
-        returns:
-            the rotated keys
-        """
-        return get_rotated_keys(self.D, self.data, gg)
-
     def times_group_element(
         self: Self,
         gg: np.ndarray,
@@ -763,7 +750,7 @@ class GeometricImage:
             times_group_element(self.D, self.data, self.parity, gg, self.covariant_axes, precision),
             self.parity,
             self.D,
-            self.is_torus,
+            rotate_is_torus(self.is_torus, gg),
             self.covariant_axes,
         )
 

--- a/src/ginjax/geometric/multi_image.py
+++ b/src/ginjax/geometric/multi_image.py
@@ -15,6 +15,7 @@ from ginjax.geometric.functional_geometric_image import (
     average_pool,
     norm,
     raise_lower,
+    rotate_is_torus,
     times_group_element,
 )
 from ginjax.geometric.geometric_image import GeometricImage, get_metric_inverse
@@ -755,17 +756,18 @@ class MultiImage:
         if self.metric_tensor_inv is not None:
             out.metric_tensor_inv = self.metric_tensor_inv.times_group_element(gg, precision)
 
-        vmap_rotate = jax.vmap(times_group_element, in_axes=(None, 0, None, None, None, None))
         for (k, parity), image_block in self.items():
-            rotated_img_block = vmap_rotate(
+            rotated_img_block = times_group_element(
                 self.D,
-                image_block.reshape((-1,) + self.get_spatial_dims() + (self.D,) * len(k)),
+                image_block,
                 parity,
                 gg,
                 k,
                 precision,
             )
-            out.append(k, parity, rotated_img_block.reshape(image_block.shape))
+            out.append(k, parity, rotated_img_block)
+
+        out.is_torus = rotate_is_torus(out.is_torus, gg)
 
         return out
 

--- a/src/ginjax/models.py
+++ b/src/ginjax/models.py
@@ -70,6 +70,7 @@ def make_conv(
     padding: Optional[Union[str, int, tuple[tuple[int, int], ...]]] = None,
     lhs_dilation: Optional[tuple[int, ...]] = None,
     rhs_dilation: Union[int, tuple[int, ...]] = 1,
+    padding_mode: str = "ZEROS",
     key: Any = None,  # any instead of arraylike because split cannot handle None
 ) -> Union[ml.ConvContract, ml.LayerWrapper]:
     """
@@ -88,6 +89,8 @@ def make_conv(
         padding: convolution padding
         lhs_dilation: left hand side dilation for transpose convolution
         rhs_dilation: right hand side dilation for dilated convolutions
+        padding_mode: for non-equivariant convolutions, define padding mode that is passed to conv.
+            For equivariant, this is a variable of the input
         key: jax.random key
 
     returns:
@@ -111,6 +114,7 @@ def make_conv(
         assert len(input_keys) == len(target_keys) == 1
         assert input_keys[0][0] == target_keys[0][0] == ((), 0)
         padding = "SAME" if padding is None else padding
+        padding_mode = padding_mode if padding == "SAME" else "ZEROS"  # only implemented for SAME
         use_bias = True if use_bias == "auto" else use_bias
         assert isinstance(use_bias, bool)
         if lhs_dilation is None:
@@ -124,6 +128,7 @@ def make_conv(
                     padding,
                     rhs_dilation,
                     use_bias=use_bias,
+                    padding_mode=padding_mode,
                     key=key,
                 ),
                 input_keys,
@@ -140,6 +145,7 @@ def make_conv(
                     padding,
                     dilation=rhs_dilation,
                     use_bias=use_bias,
+                    padding_mode=padding_mode,
                     key=key,
                 ),
                 input_keys,
@@ -347,6 +353,7 @@ class UNet(MultiImageModule):
         use_group_norm: bool = False,
         use_batch_norm: bool = False,
         mid_keys: Optional[geom.Signature] = None,
+        padding_mode: str = "ZEROS",
         key: Any = None,
     ) -> None:
         """
@@ -367,6 +374,7 @@ class UNet(MultiImageModule):
             use_group_norm: whether to use GroupNorm
             use_batch_norm: whether to use the BatchNorm, only for non-equivariant version
             mid_keys: types of images and number of channels for the mid layers, as a baseline
+            padding_mode: used for non-equivariant models, padding mode to pass to convolutions
             key: jax.random key
         """
         assert num_conv > 0
@@ -409,6 +417,7 @@ class UNet(MultiImageModule):
                     kernel_size,
                     use_group_norm,
                     use_batch_norm,
+                    padding_mode=padding_mode,
                     key=subkey,
                 )
             )
@@ -441,6 +450,7 @@ class UNet(MultiImageModule):
                         kernel_size,
                         use_group_norm,
                         use_batch_norm,
+                        padding_mode=padding_mode,
                         key=subkey,
                     )
                 )
@@ -477,6 +487,7 @@ class UNet(MultiImageModule):
                     stride,
                     padding,
                     (2,) * self.D,  # lhs_dilation
+                    padding_mode=padding_mode,
                     key=subkey,
                 ),
                 [],
@@ -506,6 +517,7 @@ class UNet(MultiImageModule):
                         kernel_size,
                         use_group_norm,
                         use_batch_norm,
+                        padding_mode=padding_mode,
                         key=subkey,
                     )
                 )
@@ -522,6 +534,7 @@ class UNet(MultiImageModule):
             equivariant,
             conv_filters,
             kernel_size,
+            padding_mode=padding_mode,
             key=subkey,
         )
 
@@ -595,6 +608,7 @@ class DilResNet(MultiImageModule):
         kernel_size: Optional[Union[int, Sequence[int]]] = None,
         use_group_norm: bool = False,
         mid_keys: Optional[geom.Signature] = None,
+        padding_mode: str = "ZEROS",
         key: Any = None,
     ) -> None:
         """
@@ -613,6 +627,7 @@ class DilResNet(MultiImageModule):
             kernel_size: sidelength(s) for the non-equivariant version
             use_group_norm: whether to use GroupNorm
             mid_keys: types of images and number of channels for the mid layers, as a baseline
+            padding_mode: used for non-equivariant models, padding mode to pass to convolutions
             key: jax.random key
         """
         self.D = D
@@ -646,6 +661,7 @@ class DilResNet(MultiImageModule):
                 equivariant,
                 conv_filters,
                 1,
+                padding_mode=padding_mode,
                 key=subkey1,
             ),
             ConvBlock(
@@ -657,6 +673,7 @@ class DilResNet(MultiImageModule):
                 equivariant,
                 conv_filters,
                 1,
+                padding_mode=padding_mode,
                 key=subkey2,
             ),
         ]
@@ -679,6 +696,7 @@ class DilResNet(MultiImageModule):
                         kernel_size,
                         use_group_norm,
                         rhs_dilation=(dilation,) * D,
+                        padding_mode=padding_mode,
                         key=subkey,
                     )
                 )
@@ -696,10 +714,20 @@ class DilResNet(MultiImageModule):
                 equivariant,
                 conv_filters,
                 1,
+                padding_mode=padding_mode,
                 key=subkey1,
             ),
             ConvBlock(
-                D, mid_keys, output_keys, use_bias, None, equivariant, conv_filters, 1, key=subkey2
+                D,
+                mid_keys,
+                output_keys,
+                use_bias,
+                None,
+                equivariant,
+                conv_filters,
+                1,
+                padding_mode=padding_mode,
+                key=subkey2,
             ),
         ]
 
@@ -770,6 +798,7 @@ class ResNet(MultiImageModule):
         use_group_norm: bool = True,
         preactivation_order: bool = True,
         mid_keys: Optional[geom.Signature] = None,
+        padding_mode: str = "ZEROS",
         key: Any = None,
     ) -> None:
         """
@@ -790,6 +819,7 @@ class ResNet(MultiImageModule):
             use_group_norm: whether to use GroupNorm
             preactivation_order: whether to use preactivation order
             mid_keys: types of images and number of channels for the mid layers, as a baseline
+            padding_mode: for non-equivariant, pass 'TOROIDAL' if all sides are toroidal
             key: jax.random key
         """
         self.D = D
@@ -823,6 +853,7 @@ class ResNet(MultiImageModule):
                 equivariant,
                 conv_filters,
                 1,
+                padding_mode=padding_mode,
                 key=subkey1,
             ),
             ConvBlock(
@@ -834,6 +865,7 @@ class ResNet(MultiImageModule):
                 equivariant,
                 conv_filters,
                 1,
+                padding_mode=padding_mode,
                 key=subkey2,
             ),
         ]
@@ -856,6 +888,7 @@ class ResNet(MultiImageModule):
                         kernel_size,
                         use_group_norm,
                         preactivation_order=preactivation_order,
+                        padding_mode=padding_mode,
                         key=subkey,
                     )
                 )
@@ -873,10 +906,20 @@ class ResNet(MultiImageModule):
                 equivariant,
                 conv_filters,
                 1,
+                padding_mode=padding_mode,
                 key=subkey1,
             ),
             ConvBlock(
-                D, mid_keys, output_keys, use_bias, None, equivariant, conv_filters, 1, key=subkey2
+                D,
+                mid_keys,
+                output_keys,
+                use_bias,
+                None,
+                equivariant,
+                conv_filters,
+                1,
+                padding_mode=padding_mode,
+                key=subkey2,
             ),
         ]
 

--- a/tests/test_functional_geometric_image.py
+++ b/tests/test_functional_geometric_image.py
@@ -57,12 +57,12 @@ class TestFunctionalGeometricImage:
         indices = jnp.arange(10 * D).reshape((10, D))
 
         img1 = jnp.ones((4, 4))
-        hashed_indices = geom.hash(D, img1, indices)
+        hashed_indices = geom.hash(D, img1.shape, indices)
         assert jnp.allclose(hashed_indices[0], jnp.array([0, 2, 0, 2, 0, 2, 0, 2, 0, 2]))
         assert jnp.allclose(hashed_indices[1], jnp.array([1, 3, 1, 3, 1, 3, 1, 3, 1, 3]))
 
         img2 = jnp.ones((3, 4))
-        hashed_indices = geom.hash(D, img2, indices)
+        hashed_indices = geom.hash(D, img2.shape, indices)
         assert jnp.allclose(hashed_indices[0], jnp.array([0, 2, 1, 0, 2, 1, 0, 2, 1, 0]))
         assert jnp.allclose(hashed_indices[1], jnp.array([1, 3, 1, 3, 1, 3, 1, 3, 1, 3]))
 

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -976,6 +976,11 @@ class TestGeometricImage:
         assert img5_flipX.spatial_dims == (3, 4)
         assert (img5_flipX.data == jnp.array([[8, 9, 10, 11], [4, 5, 6, 7], [0, 1, 2, 3]])).all()
 
+        # semi-toroidal
+        img6 = geom.GeometricImage(jnp.ones((5, 5, 2)), 0, 2, (True, False))
+        assert img6.times_group_element(left90).is_torus == (False, True)
+        assert img6.times_group_element(flipX).is_torus == (True, False)
+
     def testTimesGroupElementEven(self):
         left90 = np.array([[0, -1], [1, 0]])
         flipX = np.array([[-1, 0], [0, 1]])

--- a/tests/test_multi_image.py
+++ b/tests/test_multi_image.py
@@ -1,5 +1,6 @@
 import time
 import itertools as it
+import numpy as np
 
 import ginjax.geometric as geom
 import pytest
@@ -705,7 +706,6 @@ class TestMultiImage:
         N = 5
         channels = 3
 
-        vmap_times_gg = jax.vmap(geom.times_group_element, in_axes=(None, 0, None, None, None))
         key = random.PRNGKey(0)
         for D in [2, 3]:
             multi_image = geom.MultiImage({}, D)
@@ -725,8 +725,27 @@ class TestMultiImage:
                 rotated_multi_image = multi_image.times_group_element(gg)
 
                 for (k, parity), img_block in multi_image.items():
-                    rotated_block = vmap_times_gg(D, img_block, parity, gg, k)
+                    rotated_block = geom.times_group_element(D, img_block, parity, gg, k)
                     assert jnp.allclose(rotated_multi_image[(k, parity)], rotated_block)
+
+    def testTimesGroupElementSemiToroidal(self):
+        N = 5
+        channels = 3
+
+        # 2D
+        D = 2
+        ops = geom.make_all_operators(D)
+        multi_image1 = geom.MultiImage(
+            {((), 0): jnp.ones((channels,) + (N,) * D)}, D, (True, False)
+        )
+        assert multi_image1.times_gg_precise(ops[0]).is_torus == (True, False)  # id
+        assert multi_image1.times_gg_precise(ops[1]).is_torus == (True, False)  # flip y
+        assert multi_image1.times_gg_precise(ops[2]).is_torus == (True, False)  # flip x
+        assert multi_image1.times_gg_precise(ops[3]).is_torus == (True, False)  # flip x and y
+        assert multi_image1.times_gg_precise(ops[4]).is_torus == (False, True)  # rot 90 flip x
+        assert multi_image1.times_gg_precise(ops[5]).is_torus == (False, True)  # rot 90
+        assert multi_image1.times_gg_precise(ops[6]).is_torus == (False, True)  # rot 270
+        assert multi_image1.times_gg_precise(ops[7]).is_torus == (False, True)  # rot 90 flip y
 
     def testTimesGroupElementMetric(self):
         N = 5
@@ -1229,7 +1248,6 @@ class TestBatchMultiImage:
         batch = 4
         channels = 3
 
-        vmap_times_gg = jax.vmap(geom.times_group_element, in_axes=(None, 0, None, None, None))
         key = random.PRNGKey(0)
         for D in [2, 3]:
             spatial_dims = (N,) * D
@@ -1244,14 +1262,55 @@ class TestBatchMultiImage:
                         random.normal(subkey, shape=((batch, channels) + spatial_dims + (D,) * k)),
                     )
 
-            for gg in geom.make_all_operators(D):
+            operators = geom.make_all_operators(D)
+            for gg in operators:
+                rotated_multi_image = multi_image.times_gg_precise(gg)
+
+                for (k, parity), img_block in multi_image.items():
+                    rotated_block = geom.times_group_element(
+                        D,
+                        img_block,
+                        parity,
+                        gg,
+                        k,
+                        jax.lax.Precision.HIGHEST,
+                    )
+                    assert jnp.allclose(rotated_multi_image[(k, parity)], rotated_block)
+
+            for gg in operators:
+                assert multi_image.times_gg_precise(gg).times_gg_precise(gg.T) == multi_image
+
+    def testTimesGroupElementNonSquare(self):
+        N = 5
+        batch = 4
+        channels = 3
+
+        key = random.PRNGKey(0)
+        for D in [3]:
+            spatial_dims = (N, 2 * N, N - 2)[:D]
+            multi_image = geom.MultiImage({}, D)
+
+            for parity in [0]:
+                for k in [0]:
+                    key, subkey = random.split(key)
+                    multi_image.append(
+                        k,
+                        parity,
+                        random.normal(subkey, shape=((batch, channels) + spatial_dims + (D,) * k)),
+                    )
+
+            # rotating multi image is same as rotating individual image
+            operators = geom.make_all_operators(D)
+            for gg in operators:
                 rotated_multi_image = multi_image.times_group_element(gg)
 
                 for (k, parity), img_block in multi_image.items():
-                    rotated_block = vmap_times_gg(
-                        D, img_block.reshape((-1,) + spatial_dims + (D,) * len(k)), parity, gg, k
-                    ).reshape(img_block.shape)
+                    rotated_block = geom.times_group_element(D, img_block, parity, gg, k)
                     assert jnp.allclose(rotated_multi_image[(k, parity)], rotated_block)
+
+            # rotating then inverse rotating is same as doing nothing
+            for gg in operators:
+                assert multi_image.times_gg_precise(gg).times_gg_precise(gg.T) == multi_image
 
     def testNorm(self):
         N = 5

--- a/tests/test_multi_image.py
+++ b/tests/test_multi_image.py
@@ -1,6 +1,5 @@
 import time
 import itertools as it
-import numpy as np
 
 import ginjax.geometric as geom
 import pytest
@@ -1286,7 +1285,7 @@ class TestBatchMultiImage:
         channels = 3
 
         key = random.PRNGKey(0)
-        for D in [3]:
+        for D in [2, 3]:
             spatial_dims = (N, 2 * N, N - 2)[:D]
             multi_image = geom.MultiImage({}, D)
 

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -318,12 +318,6 @@ class TestPropositions:
         batch = 2
         channels = 3
 
-        vmap_times_gg = jax.vmap(
-            jax.vmap(geom.times_group_element, in_axes=(None, 0, None, None, None)),
-            in_axes=(None, 0, None, None, None),
-        )
-
-        prec = jax.lax.Precision.HIGHEST
         for D in [2, 3]:
             operators = geom.make_all_operators(D)
             for parity in [0, 1]:

--- a/tests/test_slow.py
+++ b/tests/test_slow.py
@@ -3,7 +3,6 @@ import pytest
 import jax.numpy as jnp
 from jax import random
 import jax.lax
-from typing_extensions import Optional
 
 TINY = 1.0e-5
 

--- a/tests/test_slow.py
+++ b/tests/test_slow.py
@@ -3,11 +3,17 @@ import pytest
 import jax.numpy as jnp
 from jax import random
 import jax.lax
+from typing_extensions import Optional
 
 TINY = 1.0e-5
 
 
-def conv_subimage(image, center_key, filter_image, filter_image_keys=None):
+def conv_subimage(
+    image: geom.GeometricImage,
+    center_key: tuple[int, ...],
+    filter_image: geom.GeometricFilter,
+    filter_image_keys=None,
+):
     """
     Get the subimage (on the torus) centered on center_idx that will be convolved with filter_image
     args:


### PR DESCRIPTION
## Changes
- add padding_mode for models that is used for non-equivariant models to set the padding mode of convolutions, which should be "CIRCULAR" when all sides are toroidal, as in cfd_2d
- fix the non-equivariant std vector scaling in cfd_2d, shallow_water
- change hash so that it just requires the spatial dims
- fix a bug with `get_rotated_keys` that could use the wrong centering coords for non-square images
- update times_group_element so that leading batch axes are handled properly
- rotate is_torus when rotating the image

## Testing
- [x] cfd_2d
- [x] shallow_water
- [x] pytest
- [x] gradient_sphere

## Doc Changes
- none