### PR TITLE
add more details to the readme, update citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 
 **Equivariant geometric convolutions for machine learning on tensor images**
 
-This package implements the GeometricImageNet which allows for writing general functions from geometric images to geometric images. Also, with an easy restriction to group invariant CNN filters, we can write CNNs that are equivariant to those groups for geometric images.
+The ginjax package implements the **G**eometric**I**mage**N**et in [jax](https://github.com/jax-ml/jax) (hence, ginjax) which allows for writing general functions from geometric images to geometric images. 
+Also, with an easy restriction to group invariant CNN filters, we can write CNNs that are equivariant to those groups for geometric images.
 
-See the paper for more details: https://arxiv.org/abs/2305.12585.
+See the paper for more details: https://royalsocietypublishing.org/doi/full/10.1098/rsta.2024.0247?af=R.
 
 See our readthedocs for <a href="https://ginjax.readthedocs.io/en/latest/">full documentation</a>.
 
@@ -22,6 +23,7 @@ See our readthedocs for <a href="https://ginjax.readthedocs.io/en/latest/">full 
 2. [Features](#features)
     1. [GeometricImage](#geometricimage)
     2. [MultiImage](#multiimage)
+    3. [Equivariance](#equivariance)
 3. [Authors and Attribution](#authors-and-attribution)
 4. [License](#license)
 
@@ -42,11 +44,74 @@ To work on this package, install the repo as an editable install by doing the fo
 
 ### GeometricImage
 
-The GeometricImage is the main concept of this package. We define a geometric image for dimension D, spatial dimensions, parity p, and tensor order k of either contravariant or covariant axes. To construct a geometric image, do: `image = GeometricImage(data, parity, D)`. Data is a jnp.array with the shape spatial dimensions followed by `(D,)*k)`. Images default to being defined on the torus, aka periodic boundary conditions. When working with a metric that is not the flat Euclidean metric, you can define which tensor axes are contravariant (the default) or covariant.
+The main concept of this package is an object called a `GeometricImage` which generalizes a normal image to include scalar images, vector images, or tensor images of any tensor order or parity.
+For example, suppose we have data of a 2 dimensional 3 by 3 vector image.
+We could construct the geometric image as follows: 
+```python
+D = 2 # 2-dimensional image, we could also do 3D.
+# data, jax array of shape (3,3,2)
+parity = 0 # even parity, its a vector image not a pseudovector image
+image = GeometricImage(data, parity, D)
+```
+Data is a jnp.array with the shape spatial dimensions followed by `(D,)*k)`. Images default to being defined on the torus, aka periodic boundary conditions. 
+When working with a metric that is not the flat Euclidean metric, you can define which tensor axes are contravariant (the default) or covariant.
+Geometric images of a particular shape, tensor order, and parity form a vector space so we have the usual operations of addition, subtraction, and scalar multiplication:
+```python
+added_image = image + image2 # addition
+subtracted_image = image - image2 # subtraction
+scaled_image = image * 3 # scalar multiplication
+```
+Additionally, if we have two images of the same spatial dimensions, but possibly different tensor orders or parities, we can multiply them where each pixel is the tensor product.
+```python
+image1 = GeometricImage(jnp.ones((3,3,D)), parity, D)
+image2 = GeometricImage(jnp.ones((3,3,D,D)), parity, D)
+image_product = image1 * image2 # data will be shape (3,3,2,2,2)
+```
+There are many more operations we can perform on geometric images including convolutions, contractions, rotations, norms, pooling, etc.
+This example is continued on our [readthedocs](https://ginjax.readthedocs.io/en/latest/quickstart/) site.
 
 ### MultiImage
 
-The MultiImage class allow us to group multiple images together that have the same dimension and spatial dimensions. MultiImage is a dictionary where the keys are (tensor order k, parity p) and the values are a image data block which has some number of initial axes followed by spatial axes and tensor axes. Common numbers of prior axes are 1 for channels, or 2 for batch followed by channels. The machine learning layers and models defined in this package expect a single axis for the channels, while the training code expects batch and then channels. You can easily construct MultiImages from images using the `from_images` function. Additionally, MultiImages can be created with an associated metric tensor field.
+The GeometricImage class is useful for exploring and experimenting with individual geometric images; however, in machine learning contexts we typically need multiple channels and batches of images.
+In addition, to build rotationally equivariant models, we may need to track multiple image types (scalar, vector, tensor, etc.) simultaneously. 
+The MultiImage class allows us to do all of this at once, only making the assumption that the images are all in the same dimensional space (2D or 3D) and they all have the same spatial dimensions.
+MultiImage is a dictionary where the keys are (tensor order k, parity p) and the values are a image data block which has some number of initial axes followed by spatial axes and tensor axes. Common numbers of prior axes are 1 for channels, or 2 for batch followed by channels. 
+For example:
+```python
+D = 2 # dimension of the space
+spatial_dims = (3,3) # image spatial dimensions
+
+# first construct multi image with channels but not batch
+multi_image1 = MultiImage(
+    { 
+        (0,0): jnp.ones((3,) + spatial_dims),  # 3 scalar channels
+        (1,0): jnp.ones((1,) + spatial_dims + (D,)) # 1 vector channel
+    }, 
+    D,
+)
+
+# now construct multi image with batch dimension
+batch = 5 # batch size
+batch_multi_image2 = MultiImage(
+    { 
+        (1,1): jnp.ones((batch,1) + spatial_dims + (D,)),  # 1 pseudovector
+        (2,0): jnp.ones((batch,2) + spatial_dims + (D,D)) # 2 2-tensor
+    }, 
+    D,
+)
+```
+The machine learning layers and models defined in this package expect a single axis for the channels, while the training code expects batch and then channels. To use MultiImages for machine learning, see the [scalar example](https://ginjax.readthedocs.io/en/latest/examples/scalar_example/) and [gradient example](https://ginjax.readthedocs.io/en/latest/examples/gradient_example/). MultiImages can also be created with an associated metric tensor field.
+
+### Equivariance
+
+The main motivation of this package is for designing neural networks on geometric images that capture the symmetries of those geometric images.
+Since we are working with discrete images, the symmetries are described by discrete groups such as translations, rotations of 90 degrees, reflections, or subgroups of these groups.
+See [Group and Invariant Filters](https://ginjax.readthedocs.io/en/latest/group_operators/) for more details.
+The scalars, vectors, and tensors of physics are equivariant to continuous rotations rather than just rotations of 90 degrees, but we do not consider them in this project to avoid voxelization issues.
+
+We want our neural network as a function of geometric images to be _equivariant_ with respect to these groups.
+If $G$ is a group with an action on vector spaces $X$ and $Y$ and $f$ is a function from $X$ to $Y$, then we say $f$ is $G$-equivariant if for all $g \in G$, $x \in X$, we have $f(g \cdot x) = g \cdot f(x)$. 
+See [Math Background](https://ginjax.readthedocs.io/en/latest/math/) for more details.
 
 ## Authors and Attribution
 - **Wilson Gregory** (JHU)
@@ -57,14 +122,18 @@ The MultiImage class allow us to group multiple images together that have the sa
 If you use this package in your own work, please cite the following:
 
 ```
-@misc{gregory2024equivariantgeometricconvolutionsemulation,
-      title={Equivariant geometric convolutions for emulation of dynamical systems}, 
-      author={Wilson G. Gregory and David W. Hogg and Ben Blum-Smith and Maria Teresa Arias and Kaze W. K. Wong and Soledad Villar},
-      year={2024},
-      eprint={2305.12585},
-      archivePrefix={arXiv},
-      primaryClass={cs.LG},
-      url={https://arxiv.org/abs/2305.12585}, 
+@article{doi:10.1098/rsta.2024.0247,
+author = {Gregory, Wilson G.  and Hogg, David W.  and Blum-Smith, Ben  and Arias, Maria Teresa  and Wong, Kaze W. K.  and Villar, Soledad },
+title = {Equivariant geometric convolutions for dynamical systems on vector and tensor images},
+journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+volume = {383},
+number = {2298},
+pages = {20240247},
+year = {2025},
+doi = {10.1098/rsta.2024.0247},
+
+URL = {https://royalsocietypublishing.org/doi/abs/10.1098/rsta.2024.0247},
+eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rsta.2024.0247},
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 This package implements the GeometricImageNet which allows for writing general functions from geometric images to geometric images. Also, with an easy restriction to group invariant CNN filters, we can write CNNs that are equivariant to those groups for geometric images.
 
-See the paper for more details: https://arxiv.org/abs/2305.12585.
+See the paper for more details: https://royalsocietypublishing.org/doi/full/10.1098/rsta.2024.0247?af=R.
 
 This is the documentation for the package [https://github.com/WilsonGregory/ginjax](https://github.com/WilsonGregory/ginjax)
 
@@ -25,11 +25,73 @@ To work on this package, install the repo as an editable install by doing the fo
 
 ### GeometricImage
 
-The GeometricImage is the main concept of this package. We define a geometric image for dimension D, spatial dimensions, parity p, and tensor order k of either contravariant or covariant axes. To construct a geometric image, do: `image = GeometricImage(data, parity, D)`. Data is a jnp.array with the shape spatial dimensions followed by `(D,)*k)`. Images default to being defined on the torus, aka periodic boundary conditions. When working with a metric that is not the flat Euclidean metric, you can define which tensor axes are contravariant (the default) or covariant.
+The main concept of this package is an object called a `GeometricImage` which generalizes a normal image to include scalar images, vector images, or tensor images of any tensor order or parity.
+For example, suppose we have data of a 2 dimensional 3 by 3 vector image.
+We could construct the geometric image as follows: 
+```python
+D = 2 # 2-dimensional image, we could also do 3D.
+# data, jax array of shape (3,3,2)
+parity = 0 # even parity, its a vector image not a pseudovector image
+image = GeometricImage(data, parity, D)
+```
+Data is a jnp.array with the shape spatial dimensions followed by `(D,)*k)`. Images default to being defined on the torus, aka periodic boundary conditions. 
+When working with a metric that is not the flat Euclidean metric, you can define which tensor axes are contravariant (the default) or covariant.
+Geometric images of a particular shape, tensor order, and parity form a vector space so we have the usual operations of addition, subtraction, and scalar multiplication:
+```python
+added_image = image + image2 # addition
+subtracted_image = image - image2 # subtraction
+scaled_image = image * 3 # scalar multiplication
+```
+Additionally, if we have two images of the same spatial dimensions, but possibly different tensor orders or parities, we can multiply them where each pixel is the tensor product.
+```python
+image1 = GeometricImage(jnp.ones((3,3,D)), parity, D)
+image2 = GeometricImage(jnp.ones((3,3,D,D)), parity, D)
+image_product = image1 * image2 # data will be shape (3,3,2,2,2)
+```
+There are many more operations we can perform on geometric images including convolutions, contractions, rotations, norms, pooling, etc.
+This example is continued in [Quickstart](https://ginjax.readthedocs.io/en/latest/quickstart/) site.
 
 ### MultiImage
+The GeometricImage class is useful for exploring and experimenting with individual geometric images; however, in machine learning contexts we typically need multiple channels and batches of images.
+In addition, to build rotationally equivariant models, we may need to track multiple image types (scalar, vector, tensor, etc.) simultaneously. 
+The MultiImage class allows us to do all of this at once, only making the assumption that the images are all in the same dimensional space (2D or 3D) and they all have the same spatial dimensions.
+MultiImage is a dictionary where the keys are (tensor order k, parity p) and the values are a image data block which has some number of initial axes followed by spatial axes and tensor axes. Common numbers of prior axes are 1 for channels, or 2 for batch followed by channels. 
+For example:
+```python
+D = 2 # dimension of the space
+spatial_dims = (3,3) # image spatial dimensions
 
-The MultiImage class allow us to group multiple images together that have the same dimension and spatial dimensions. MultiImage is a dictionary where the keys are (tensor order k, parity p) and the values are a image data block which has some number of initial axes followed by spatial axes and tensor axes. Common numbers of prior axes are 1 for channels, or 2 for batch followed by channels. The machine learning layers and models defined in this package expect a single axis for the channels, while the training code expects batch and then channels. You can easily construct MultiImages from images using the `from_images` function. Additionally, MultiImages can be created with an associated metric tensor field.
+# first construct multi image with channels but not batch
+multi_image1 = MultiImage(
+    { 
+        (0,0): jnp.ones((3,) + spatial_dims),  # 3 scalar channels
+        (1,0): jnp.ones((1,) + spatial_dims + (D,)) # 1 vector channel
+    }, 
+    D,
+)
+
+# now construct multi image with batch dimension
+batch = 5 # batch size
+batch_multi_image2 = MultiImage(
+    { 
+        (1,1): jnp.ones((batch,1) + spatial_dims + (D,)),  # 1 pseudovector
+        (2,0): jnp.ones((batch,2) + spatial_dims + (D,D)) # 2 2-tensor
+    }, 
+    D,
+)
+```
+The machine learning layers and models defined in this package expect a single axis for the channels, while the training code expects batch and then channels. To use MultiImages for machine learning, see the [scalar example](https://ginjax.readthedocs.io/en/latest/examples/scalar_example/) and [gradient example](https://ginjax.readthedocs.io/en/latest/examples/gradient_example/). MultiImages can also be created with an associated metric tensor field.
+
+### Equivariance
+
+The main motivation of this package is for designing neural networks on geometric images that capture the symmetries of those geometric images.
+Since we are working with discrete images, the symmetries are described by discrete groups such as translations, rotations of 90 degrees, reflections, or subgroups of these groups.
+See [Group and Invariant Filters](https://ginjax.readthedocs.io/en/latest/group_operators/) for more details.
+The scalars, vectors, and tensors of physics are equivariant to continuous rotations rather than just rotations of 90 degrees, but we do not consider them in this project to avoid voxelization issues.
+
+We want our neural network as a function of geometric images to be _equivariant_ with respect to these groups.
+If $G$ is a group with an action on vector spaces $X$ and $Y$ and $f$ is a function from $X$ to $Y$, then we say $f$ is $G$-equivariant if for all $g \in G$, $x \in X$, we have $f(g \cdot x) = g \cdot f(x)$. 
+See [Math Background](https://ginjax.readthedocs.io/en/latest/math/) for more details.
 
 ## Authors and Attribution
 - **Wilson Gregory** (JHU)
@@ -40,14 +102,18 @@ The MultiImage class allow us to group multiple images together that have the sa
 If you use this package in your own work, please cite the following:
 
 ```
-@misc{gregory2024equivariantgeometricconvolutionsemulation,
-      title={Equivariant geometric convolutions for emulation of dynamical systems}, 
-      author={Wilson G. Gregory and David W. Hogg and Ben Blum-Smith and Maria Teresa Arias and Kaze W. K. Wong and Soledad Villar},
-      year={2024},
-      eprint={2305.12585},
-      archivePrefix={arXiv},
-      primaryClass={cs.LG},
-      url={https://arxiv.org/abs/2305.12585}, 
+@article{doi:10.1098/rsta.2024.0247,
+author = {Gregory, Wilson G.  and Hogg, David W.  and Blum-Smith, Ben  and Arias, Maria Teresa  and Wong, Kaze W. K.  and Villar, Soledad },
+title = {Equivariant geometric convolutions for dynamical systems on vector and tensor images},
+journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+volume = {383},
+number = {2298},
+pages = {20240247},
+year = {2025},
+doi = {10.1098/rsta.2024.0247},
+
+URL = {https://royalsocietypublishing.org/doi/abs/10.1098/rsta.2024.0247},
+eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rsta.2024.0247},
 }
 ```
 

--- a/docs/math.md
+++ b/docs/math.md
@@ -3,8 +3,7 @@ This page is intended to be a brief introduction to the mathematics behind this 
 Let $G$ be a group with an action on vector spaces $X$ and $Y$. 
 Let $f$ be a function from $X$ to $Y$. 
 Then we say $f$ is $G$-equivariant if for all $g \in G$, $x \in X$, we have $f(g \cdot x) = g \cdot f(x)$. 
-We will consider our group $G$ to be the _hyperoctahedral group_ of dimension $d$, denoted $G_{N,d}$. 
-This is the group of translations, rotations, and reflections of a $d$-dimensional hypercube. 
+We will consider our group $G$ to be $G_{N,d}$, the semidirect product of translations on the $d$-dimensional torus with sidelengh $N$ and rotations, and reflections of a $d$-dimensional hypercube. 
 This group will act on _geometric images_, that is images where every pixel is a scalar, vector, or higher order tensor. 
 
 Lets consider some examples of geometric images. 


### PR DESCRIPTION
## Changes
- none

## Testing
- none

## Doc Changes
- expand features section to include small code snippets for creating the options, as well as links to the more involved examples on the doc site
- spell out that ginjax comes from GeometricImageNet jax in the description
- update the citation
- add a small equivariance section to the readme, with links to the longer descriptions